### PR TITLE
Fall back to using primary site ID when accessed through CLI

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -73,8 +73,14 @@ class Translator extends Plugin
             Elements::EVENT_BEFORE_SAVE_ELEMENT,
             function (ElementEvent $event) {
                 $element = $event->element;
+
                 // Set current Site id
-                $siteId = Craft::$app->request->getBodyParam('siteId');
+                if (!Craft::$app->request->isConsoleRequest) {
+                    $siteId = Craft::$app->request->getBodyParam('siteId');
+                } else {
+                    $siteId = Craft::$app->sites->getPrimarySite()->id;
+                }
+
                 if (!ElementHelper::isDraftOrRevision($element) and isset($_POST['fields']) and ($element->siteId == $siteId)) {
                     $translationsFromInput = [];
                     $locale = Craft::$app->sites->getSiteById($element->siteId)->language;


### PR DESCRIPTION
After installing and deploying the plugin to an existing site we weren't able to apply project config changes anymore and our deployment pipeline failed:

```
Installing plugin "translator" ... done
Applying changes from your project config files ...
- updating dateModified ... done
- adding globalSets.e2de0867-9e57-4fa4-9283-7f33ab58e1ec.fieldLayouts.583c57dd-b99a-4ca7-966e-d1f1dcf4ac0a.tabs.0.elements.0 ...
  - adding globalSets.e2de0867-9e57-4fa4-9283-7f33ab58e1ec ...
error: Calling unknown method: craft\console\Request::getBodyParam()
```

`getBodyParam()` doesn't exist on the request object when we're in a CLI context. I've fixed the issue by adding a conditional that checks whether the request is a console request and falling back to the default site ID in that case.